### PR TITLE
fixes #17

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -30,6 +30,12 @@ class Watcher {
       }
 
       let localPath = path.join(workingDir, fileName)
+
+      // Skip excluded.
+      if (exclude && anymatch(exclude, localPath)) {
+        return
+      }
+
       log.debug('Changed:', localPath)
 
       fs.stat(localPath, (err, stats) => {
@@ -38,11 +44,6 @@ class Watcher {
           if (err.code === 'ENOENT') {
             callback(localPath)
           }
-          return
-        }
-
-        // Skip directory changes.
-        if (event === 'change' && stats && stats.isDirectory()) {
           return
         }
 


### PR DESCRIPTION
moves excludes check before fs stat check, files that are created temporarily (presumably by editors) can be deleted before the AEM watch even gets a chance to evaluate the file status, this results in the file being returned as a valid deletition via the callback on line 45