### PR TITLE
#26 micromatch arguments fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aemsync",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Adobe AEM Synchronization Tool",
   "author": "Michal Kochel <gavoja@gmail.com>",
   "keywords": [

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -13,7 +13,7 @@ class Watcher {
       log.debug('Changed:', localPath)
 
       // Skip excluded.
-      if (exclude && mm(exclude, localPath)) {
+      if (exclude && mm([localPath], exclude).length > 0) {
         return
       }
 


### PR DESCRIPTION
If `exclude` is used, changes are not detected, since Micromatch condition is always `true`:
https://github.com/gavoja/aemsync/issues/26

```
if (exclude && mm(exclude, localPath) {
  return
}
```

Micromatch arguments are in wrong order.
First argument must be an Array.
It also return an Array, so condition should be against Array length.

https://www.npmjs.com/package/micromatch#micromatch-1

```
Params

list {Array}: A list of strings to match
patterns {String|Array}: One or more glob patterns to use for matching.
```

