### PR TITLE
add support for junctions

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -28,7 +28,7 @@ class Sender {
     let timestamp = Date.now()
 
     let options = {}
-    options.path = PACKAGE_MANAGER_URL
+    options.path = params.path + PACKAGE_MANAGER_URL
     options.port = params.port
     options.host = params.hostname
     options.headers = {


### PR DESCRIPTION
for example on our local setup our author instance is behind a /MB juntion.
The results in the packagemgr url to be http://admin:admin@localhost:4502/MB/crx/packagemgr/index.jsp and this was currently not support as the path is not taken into account after parsing the url of the target