### PR TITLE
Fix order of micromatch parameters

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -13,7 +13,7 @@ class Watcher {
       log.debug('Changed:', localPath)
 
       // Skip excluded.
-      if (exclude && mm([localPath], {dot: true}, exclude).length > 0) {
+      if (exclude && mm([localPath], exclude, {dot: true}).length > 0) {
         return
       }
 


### PR DESCRIPTION
Updated the order of the micromatch parameters according to its documentation: https://github.com/micromatch/micromatch#api

Is also the fix for https://github.com/gavoja/aemsync/issues/32 and https://github.com/gavoja/aemsync/issues/38