### PR TITLE
Fix #36 Package manager clutter

### DIFF
--- a/data/package_content/META-INF/vault/properties.xml
+++ b/data/package_content/META-INF/vault/properties.xml
@@ -3,7 +3,7 @@
 <properties>
 <comment>FileVault Package Properties</comment>
 <entry key="createdBy">AEM Synchronization Tool</entry>
-<!--<entry key="name">cqsync-copy</entry>-->
+<entry key="name">aemsync</entry>
 <!--<entry key="lastModified">2014-06-25T10:14:56.742+02:00</entry>-->
 <!--<entry key="lastModifiedBy">admin</entry>-->
 <!--<entry key="created">2014-06-25T10:14:57.020+02:00</entry>-->


### PR DESCRIPTION
Since JCRVLT-192 FileVault needs both a name and group in the properties.xml, otherwise it defaults to the pack_{guid}.zip naming for the package.

This change was part of FileVault 3.1.42 and is now part of AEM 6.3 SP2 and AEM 6.4.

Commit with relevant changes: https://github.com/apache/jackrabbit-filevault/commit/da786663ea49ddbd9b276871d92661f598158c08