### PR TITLE
Support multiple excludes

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -13,7 +13,15 @@ class Watcher {
       log.debug('Changed:', localPath)
 
       // Skip excluded.
-      if (exclude && mm(localPath, exclude, {dot: true})) {
+      if (exclude && Array.isArray(exclude)) {
+        const shouldBeExcluded = exclude.some(function (excludeOne) {
+          return mm(localPath, excludeOne, {dot: true});
+        });
+
+        if (shouldBeExcluded) {
+          return
+        }
+      } else if (exclude && mm(localPath, exclude, {dot: true})) {
         return
       }
 


### PR DESCRIPTION
Bug:
If the user runs `aemsync -e "**.css" -e "**.js"` with two excludes, as opposed to just one exclude (`aemsync -e "**.css"`), minimatch throws the following error:

```
Scanning: ....path/npm-packages/aemsync ...
Awaiting changes ...
....path/npm-packages/aemsync/node_modules/minimatch/minimatch.js:94
    throw new TypeError('glob pattern string required')
```

Fix:
This PR solves the issue by testing if the pattern is an array. If it is, each pattern runs through the minimatch function separately.