### PR TITLE
Don't include underscore in first capture group of the regular expression

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -232,7 +232,7 @@ class Package {
     // consistent.
     return this._cleanPath(localPath)
       .replace(/(.*jcr_root)|(\.xml$)|(\.dir)/g, '')
-      .replace(/\/_([^/]*)_([^/]*)$/g, '/$1:$2')
+      .replace(/\/_([^/^_]*)_([^/]*)$/g, '/$1:$2')
   }
 }
 


### PR DESCRIPTION
When a path contains more than 2 underscores, the replace logic to change the name to eg `cq:design_dialog` breaks and the result is a filter with `cq_design:dialog` instead.