### PR TITLE
fix log output formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,8 +94,8 @@ function main () {
   log.info(`aemsync version ${version}
 
     Watch over: ${log.gray(workingDir)}
-       Targets: ${log.gray(targets.map((t, ii) => ii === 0 ? t : ''.padStart(16, ' ') + t).join('\n'))}
-       Exclude: ${log.gray(exclude.map((x, ii) => ii === 0 ? x : ''.padStart(16, ' ') + x).join('\n'))}
+       Targets: ${targets.map(t => log.gray(t)).join('\n'.padEnd(17, ' '))}
+       Exclude: ${exclude.map(x => log.gray(x)).join('\n'.padEnd(17, ' '))}
       Interval: ${log.gray(interval)}
   `)
 


### PR DESCRIPTION
Hi,
Currently I am running `aemsync` via [concurrently](https://github.com/kimmobrunfeldt/concurrently).
The outputs color is weird formatted on the multiline outputs
<img width="760" alt="Screenshot 2021-01-26 at 18 30 07" src="https://user-images.githubusercontent.com/23639869/105883514-3b3fb300-6007-11eb-90c1-59ca9c06ba21.png">
This PR aims to fix that by just colorizing the actual text output.