### PR TITLE
Fixed issues when a lot of files changed exceptions stopping aemsync with error.

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -15,20 +15,27 @@ class Pipeline {
     this.checkBeforePush = opts.checkBeforePush || defaults.checkBeforePush
     this.packmgrPath = opts.packmgrPath || defaults.packmgrPath
     this.targets = opts.targets || defaults.target
-    this.interval = opts.interval || defaults.interval
+    this.intervalDelay = opts.intervalDelay || defaults.interval
     this.exclude = opts.exclude || defaults.exclude
     this.onPushEnd = opts.onPushEnd || function () {}
+    this.intervalID = 0;
   }
 
   start () {
-    setInterval(async () => {
+    this.intervalID = setInterval(async () => {
       await this._processQueue()
-    }, this.interval)
+    }, this.intervalDelay)
+  }
+
+  stop () {
+    clearInterval(this.intervalID);
   }
 
   enqueue (localPath) {
     log.debug(`Changed: ${localPath}`)
+    this.stop();
     this.queue.push(localPath)
+    this.start();
   }
 
   async push (pathToPush) {


### PR DESCRIPTION
What have been added

1. Added retrying on zip file/directory adding.
2. Added debouncing on enqueue new file changed.

Before this fixes, we encountered 50% failure rate when using aemsync.
After fixes all exceptions gone.

Lets review and push this fix into main repository.