### PR TITLE
AEM sync blows out install folder

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   workingDir: '.',
-  exclude: ['**/jcr_root/*', '**/@(.git|.svn|.hg|target)', '**/@(.git|.svn|.hg|target)/**'],
+  exclude: ['**/jcr_root/*', '**/@(.git|.svn|.hg|target|install)', '**/@(.git|.svn|.hg|target|install)/**'],
   packmgrPath: '/crx/packmgr/service.jsp',
   targets: ['http://admin:admin@localhost:4502'],
   interval: 300,


### PR DESCRIPTION
I would suggest that `install` gets added to the list of folders to ignore, as I've had several AEM instances have their `/apps/*name*/install/` folder wiped out on sync randomly. 

To be honest, I haven't figured out _why_ it does it, just that it does. Can we add `install` to the ignore list so that Maven handles those updates and AEM sync leaves them alone?