### PR TITLE
Fixed typo in args parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,7 +241,7 @@ function getArgs () {
 
   return {
     payload: args.p ? args.p.map(p => path.resolve(p)) : null,
-    workingDir: path.resolve(args?.d?.[0] ?? DEFAULTS.workingDir),
+    workingDir: path.resolve(args?.w?.[0] ?? DEFAULTS.workingDir),
     targets: args.t ?? DEFAULTS.targets,
     exclude: args.e ?? DEFAULTS.exclude,
     delay: Number(args?.d?.[0]) || DEFAULTS.delay,


### PR DESCRIPTION
There is a typo in the function used to parse incoming parameters