### PR TITLE
Fix checkIfUp option

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,17 @@ async function post ({ archivePath, target, packmgrPath, checkIfUp }) {
 
 async function check (target) {
   try {
-    const res = await fetch(target)
+    let url = target
+    const headers = new Headers()
+    const regex = /\/\/(.*:.*)@/gm
+    const credential = regex.exec(target)
+
+    if (credential !== null) {
+      headers.append('Authorization', `Basic ${btoa(credential[1])}`)
+      url = target.replace(`${credential[1]}@`, '')
+    }
+
+    const res = await fetch(url, { headers })
     return res.status === 200
   } catch (err) {
     log.debug(err.message)

--- a/index.js
+++ b/index.js
@@ -125,17 +125,13 @@ async function post ({ archivePath, target, packmgrPath, checkIfUp }) {
 
 async function check (target) {
   try {
-    let url = target
-    const headers = new Headers()
-    const regex = /\/\/(.*:.*)@/gm
-    const credential = regex.exec(target)
-
-    if (credential !== null) {
-      headers.append('Authorization', `Basic ${btoa(credential[1])}`)
-      url = target.replace(`${credential[1]}@`, '')
-    }
-
-    const res = await fetch(url, { headers })
+    const url = new URL(target)
+    const auth = `${url.username}:${url.password}`
+    url.username = ''
+    url.password = ''
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Basic ${btoa(auth)}` }
+    })
     return res.status === 200
   } catch (err) {
     log.debug(err.message)


### PR DESCRIPTION
Hello !

I've just migrate my project from aemsync 4.0.3 to 5.0.5, and I've notice that the option checkIfUp is always returning an error.

I've search why and found out that fetch doesn't allow to embed credentials into the url.

```
TypeError: http://admin:admin@localhost:4502/ is an url with embedded credentials.
    at new Request (ui.frontend/node_modules/node-fetch/src/request.js:60:10)
```

To minimize the change, I've update the code to remove the credential from the target and pass it as headers.