### PR TITLE
fix: prevent sibling-prefix collision in package dedup

### DIFF
--- a/src/package.js
+++ b/src/package.js
@@ -105,12 +105,12 @@ export default class Package {
       }
 
       // Skip if parent already added (with exception of .content.xml).
-      if (zipPath.startsWith(existingZipPath) && !zipPath.endsWith('.content.xml')) {
+      if (zipPath.startsWith(existingZipPath + '/') && !zipPath.endsWith('.content.xml')) {
         return log.debug(`Parent already added to package, skipping: ${zipPath}`)
       }
 
       // Remove child if path to add is a parent.
-      if (existingZipPath.startsWith(zipPath)) {
+      if (existingZipPath.startsWith(zipPath + '/')) {
         log.debug(`Removing child: ${existingZipPath}`)
         this.entries.splice(i, 1)
       }

--- a/test/cases/aemsync.test.js
+++ b/test/cases/aemsync.test.js
@@ -429,3 +429,69 @@ test('+ component', async () => {
     ]
   })
 })
+
+test('+ sibling folders with shared prefix', async () => {
+  add('jcr_root/apps/myapp/clientlib-site')
+  add('jcr_root/apps/myapp/clientlib-site-new')
+  await expect({
+    entries: [
+      'META-INF/',
+      'META-INF/vault/',
+      'META-INF/vault/config.xml',
+      'META-INF/vault/definition/',
+      'META-INF/vault/definition/.content.xml@vlt:PackageDefinition',
+      'META-INF/vault/filter.xml',
+      'META-INF/vault/nodetypes.cnd',
+      'META-INF/vault/properties.xml',
+      'jcr_root/',
+      'jcr_root/aemsync.txt',
+      'jcr_root/apps/.content.xml@nt:folder',
+      'jcr_root/apps/myapp/.content.xml@nt:folder',
+      'jcr_root/apps/myapp/clientlib-site/',
+      'jcr_root/apps/myapp/clientlib-site/.content.xml@nt:folder',
+      'jcr_root/apps/myapp/clientlib-site-new/',
+      'jcr_root/apps/myapp/clientlib-site-new/.content.xml@nt:folder'
+    ],
+    filter: [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<workspaceFilter version="1.0">',
+      '<filter root="/apps/myapp">',
+      '<exclude pattern="/apps/myapp/.*" />',
+      '<include pattern="/apps/myapp/clientlib-site" />',
+      '<include pattern="/apps/myapp/clientlib-site/.*" />',
+      '</filter>',
+      '',
+      '<filter root="/apps/myapp/clientlib-site">',
+      '<exclude pattern="/apps/myapp/clientlib-site/.*" />',
+      '<include pattern="/apps/myapp/clientlib-site/.content" />',
+      '<include pattern="/apps/myapp/clientlib-site/.content/.*" />',
+      '</filter>',
+      '',
+      '<filter root="/apps/myapp">',
+      '<exclude pattern="/apps/myapp/.*" />',
+      '<include pattern="/apps/myapp/.content" />',
+      '<include pattern="/apps/myapp/.content/.*" />',
+      '</filter>',
+      '',
+      '<filter root="/apps">',
+      '<exclude pattern="/apps/.*" />',
+      '<include pattern="/apps/.content" />',
+      '<include pattern="/apps/.content/.*" />',
+      '</filter>',
+      '',
+      '<filter root="/apps/myapp">',
+      '<exclude pattern="/apps/myapp/.*" />',
+      '<include pattern="/apps/myapp/clientlib-site-new" />',
+      '<include pattern="/apps/myapp/clientlib-site-new/.*" />',
+      '</filter>',
+      '',
+      '<filter root="/apps/myapp/clientlib-site-new">',
+      '<exclude pattern="/apps/myapp/clientlib-site-new/.*" />',
+      '<include pattern="/apps/myapp/clientlib-site-new/.content" />',
+      '<include pattern="/apps/myapp/clientlib-site-new/.content/.*" />',
+      '</filter>',
+      '</workspaceFilter>'
+    ]
+  })
+})
+

--- a/test/cases/aemsync.test.js
+++ b/test/cases/aemsync.test.js
@@ -494,4 +494,3 @@ test('+ sibling folders with shared prefix', async () => {
     ]
   })
 })
-

--- a/test/cases/aemsync.test.js
+++ b/test/cases/aemsync.test.js
@@ -71,7 +71,11 @@ before(() => {
   watch()
 })
 
-after(() => {
+after(async () => {
+  // The watcher generator never ends, so the process must be terminated.
+  // Yield first so the last test's result flushes to the runner; exiting
+  // immediately drops it and the final test silently goes unreported.
+  await delay(500)
   process.exit(0)
 })
 
@@ -196,8 +200,13 @@ test('- file.txt', async () => {
   })
 })
 
-test('+ folder', async () => {
-  add(`${COMPONENT}/folder`)
+// The folder name must not be a name-prefix of its fixture siblings
+// (e.g. 'folder' vs 'folder-node'). On Linux, Node's recursive fs.watch
+// stops tracking prefix-sharing siblings when a directory is deleted
+// (nodejs/node lib/internal/fs/recursive_watch.js uses a bare startsWith)
+// and then emits spurious rename events for them, breaking the assertions.
+test('+ my-folder', async () => {
+  add(`${COMPONENT}/my-folder`)
   await expect({
     entries: [
       'META-INF/',
@@ -213,22 +222,22 @@ test('+ folder', async () => {
       'jcr_root/apps/.content.xml@nt:folder',
       'jcr_root/apps/myapp/.content.xml@nt:folder',
       'jcr_root/apps/myapp/component/.content.xml@cq:Component',
-      'jcr_root/apps/myapp/component/folder/',
-      'jcr_root/apps/myapp/component/folder/.content.xml@nt:folder'
+      'jcr_root/apps/myapp/component/my-folder/',
+      'jcr_root/apps/myapp/component/my-folder/.content.xml@nt:folder'
     ],
     filter: [
       '<?xml version="1.0" encoding="UTF-8"?>',
       '<workspaceFilter version="1.0">',
       '<filter root="/apps/myapp/component">',
       '<exclude pattern="/apps/myapp/component/.*" />',
-      '<include pattern="/apps/myapp/component/folder" />',
-      '<include pattern="/apps/myapp/component/folder/.*" />',
+      '<include pattern="/apps/myapp/component/my-folder" />',
+      '<include pattern="/apps/myapp/component/my-folder/.*" />',
       '</filter>',
       '',
-      '<filter root="/apps/myapp/component/folder">',
-      '<exclude pattern="/apps/myapp/component/folder/.*" />',
-      '<include pattern="/apps/myapp/component/folder/.content" />',
-      '<include pattern="/apps/myapp/component/folder/.content/.*" />',
+      '<filter root="/apps/myapp/component/my-folder">',
+      '<exclude pattern="/apps/myapp/component/my-folder/.*" />',
+      '<include pattern="/apps/myapp/component/my-folder/.content" />',
+      '<include pattern="/apps/myapp/component/my-folder/.content/.*" />',
       '</filter>',
       '',
       '<filter root="/apps/myapp/component">',
@@ -253,8 +262,8 @@ test('+ folder', async () => {
   })
 })
 
-test('+ folder/sub-folder', async () => {
-  add(`${COMPONENT}/folder/sub-folder`)
+test('+ my-folder/sub-folder', async () => {
+  add(`${COMPONENT}/my-folder/sub-folder`)
   await expect({
     entries: [
       'META-INF/',
@@ -270,29 +279,29 @@ test('+ folder/sub-folder', async () => {
       'jcr_root/apps/.content.xml@nt:folder',
       'jcr_root/apps/myapp/.content.xml@nt:folder',
       'jcr_root/apps/myapp/component/.content.xml@cq:Component',
-      'jcr_root/apps/myapp/component/folder/.content.xml@nt:folder',
-      'jcr_root/apps/myapp/component/folder/sub-folder/',
-      'jcr_root/apps/myapp/component/folder/sub-folder/.content.xml@nt:folder'
+      'jcr_root/apps/myapp/component/my-folder/.content.xml@nt:folder',
+      'jcr_root/apps/myapp/component/my-folder/sub-folder/',
+      'jcr_root/apps/myapp/component/my-folder/sub-folder/.content.xml@nt:folder'
     ],
     filter: [
       '<?xml version="1.0" encoding="UTF-8"?>',
       '<workspaceFilter version="1.0">',
-      '<filter root="/apps/myapp/component/folder">',
-      '<exclude pattern="/apps/myapp/component/folder/.*" />',
-      '<include pattern="/apps/myapp/component/folder/sub-folder" />',
-      '<include pattern="/apps/myapp/component/folder/sub-folder/.*" />',
+      '<filter root="/apps/myapp/component/my-folder">',
+      '<exclude pattern="/apps/myapp/component/my-folder/.*" />',
+      '<include pattern="/apps/myapp/component/my-folder/sub-folder" />',
+      '<include pattern="/apps/myapp/component/my-folder/sub-folder/.*" />',
       '</filter>',
       '',
-      '<filter root="/apps/myapp/component/folder/sub-folder">',
-      '<exclude pattern="/apps/myapp/component/folder/sub-folder/.*" />',
-      '<include pattern="/apps/myapp/component/folder/sub-folder/.content" />',
-      '<include pattern="/apps/myapp/component/folder/sub-folder/.content/.*" />',
+      '<filter root="/apps/myapp/component/my-folder/sub-folder">',
+      '<exclude pattern="/apps/myapp/component/my-folder/sub-folder/.*" />',
+      '<include pattern="/apps/myapp/component/my-folder/sub-folder/.content" />',
+      '<include pattern="/apps/myapp/component/my-folder/sub-folder/.content/.*" />',
       '</filter>',
       '',
-      '<filter root="/apps/myapp/component/folder">',
-      '<exclude pattern="/apps/myapp/component/folder/.*" />',
-      '<include pattern="/apps/myapp/component/folder/.content" />',
-      '<include pattern="/apps/myapp/component/folder/.content/.*" />',
+      '<filter root="/apps/myapp/component/my-folder">',
+      '<exclude pattern="/apps/myapp/component/my-folder/.*" />',
+      '<include pattern="/apps/myapp/component/my-folder/.content" />',
+      '<include pattern="/apps/myapp/component/my-folder/.content/.*" />',
       '</filter>',
       '',
       '<filter root="/apps/myapp/component">',
@@ -317,8 +326,8 @@ test('+ folder/sub-folder', async () => {
   })
 })
 
-test('- folder', async () => {
-  remove(`${COMPONENT}/folder`)
+test('- my-folder', async () => {
+  remove(`${COMPONENT}/my-folder`)
   await expect({
     entries: [
       'META-INF/',
@@ -338,7 +347,7 @@ test('- folder', async () => {
     filter: [
       '<?xml version="1.0" encoding="UTF-8"?>',
       '<workspaceFilter version="1.0">',
-      '<filter root="/apps/myapp/component/folder" />',
+      '<filter root="/apps/myapp/component/my-folder" />',
       '',
       '<filter root="/apps/myapp/component">',
       '<exclude pattern="/apps/myapp/component/.*" />',
@@ -447,10 +456,10 @@ test('+ sibling folders with shared prefix', async () => {
       'jcr_root/aemsync.txt',
       'jcr_root/apps/.content.xml@nt:folder',
       'jcr_root/apps/myapp/.content.xml@nt:folder',
-      'jcr_root/apps/myapp/clientlib-site/',
-      'jcr_root/apps/myapp/clientlib-site/.content.xml@nt:folder',
       'jcr_root/apps/myapp/clientlib-site-new/',
-      'jcr_root/apps/myapp/clientlib-site-new/.content.xml@nt:folder'
+      'jcr_root/apps/myapp/clientlib-site-new/.content.xml@nt:folder',
+      'jcr_root/apps/myapp/clientlib-site/',
+      'jcr_root/apps/myapp/clientlib-site/.content.xml@nt:folder'
     ],
     filter: [
       '<?xml version="1.0" encoding="UTF-8"?>',


### PR DESCRIPTION
Fixes #77.

## Summary

`Package._deduplicateAndAdd` used raw `startsWith` to detect parent/child relationships between zip paths. Because zip paths have no trailing slash, siblings sharing a name prefix (e.g. `clientlib-site` and `clientlib-site-new`) collided: the longer sibling was silently dropped via the debug-only "Parent already added" log, leaving the sync incomplete with no error surfaced to the user.

Adds a `/` boundary to both prefix checks so only true parent/child paths match. The equality case is already handled earlier in the loop, so this covers all real subpath relationships, and the `.content.xml` carve-out still works (`.../component/.content.xml` still starts with `.../component/` and the `endsWith('.content.xml')` guard keeps it from being skipped).

## Test harness fixes

The first CI run surfaced three test-harness issues, fixed in this PR as well:

- **The last test in the file was silently unreported.** The `after()` hook calls `process.exit(0)` (needed because the watch generator never ends), but exiting immediately dropped the final test's result before it reached the runner — CI and local runs reported `tests 7` with 8 tests registered, so the last test's assertion never counted. The hook now yields briefly before exiting.
- **`- folder` failed on Linux only.** Node's recursive `fs.watch` on Linux has the very same sibling-prefix `startsWith` bug this PR fixes in aemsync ([`lib/internal/fs/recursive_watch.js`](https://github.com/nodejs/node/blob/v22.x/lib/internal/fs/recursive_watch.js) `#unwatchFiles`; fixed on `main` with `file + pathSep`, still present in v22.x and v24.x): deleting `component/folder` drops watcher tracking of the sibling fixtures `folder-node` and `folder-node-nested` and re-emits spurious rename events for them. On master, aemsync's buggy dedup coincidentally swallowed exactly those events (they share the `folder` prefix), so the test only passed by two bugs cancelling out. The transient test folder is renamed to `my-folder` so it shares no prefix with fixture siblings.
- **Wrong expected zip-entry order in the new test.** Archive entries are sorted asciibetically, where `clientlib-site-new/` sorts before `clientlib-site/` (`-` < `/`).

## Test plan

- [x] New integration test `+ sibling folders with shared prefix` in `test/cases/aemsync.test.js` adds two sibling folders with shared prefix and asserts both end up in the archive entries and filter.
- [x] All previously-passing tests still pass locally with `node --test test/cases/aemsync.test.js`. (The pre-existing `Excluded files and directories` failure also fails on master locally on macOS and is unrelated to this change; it passes on Linux CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
